### PR TITLE
Cloud formation stack update support for endpoint route away

### DIFF
--- a/cdn.yml
+++ b/cdn.yml
@@ -42,6 +42,9 @@ Resources:
               - GET
               - HEAD
               - OPTIONS
+            DefaultTTL: 0
+            MaxTTL: 0
+            MinTTL: 0
             Compress: true
             ForwardedValues:
               Headers:

--- a/cf_gateway.ipynb
+++ b/cf_gateway.ipynb
@@ -471,7 +471,78 @@
    "outputs": [],
    "source": [
     "%%bash -s \"$list_uri\" \"$key_val\"\n",
-    "curl -X POST -H x-api-key:$2 $1 --data '{ \"text\": \"Learn Serverless\" }'"
+    "curl -X POST -H x-api-key:$2 $1 --data '{ \"text\": \"Research fear of clowns\" }'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cloud Formation Update - Region Route Away\n",
+    "\n",
+    "This section shows how to update the api origin associated with the cloud front fronting the (cloud front\n",
+    "wrapping) the API endpoint.\n",
+    "\n",
+    "To do - how do we get the route away time down? Is it a TTL somewhere maybe in cloud front?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "route_away_endpoint = west_endpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from urlparse import urlparse\n",
+    "parsed_uri = urlparse(route_away_endpoint)\n",
+    "route_away_origin = parsed_uri.netloc\n",
+    "print route_away_origin"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "response = cformation_east.update_stack(\n",
+    "    StackName=api_stack_name,\n",
+    "    UsePreviousTemplate=True,\n",
+    "    Parameters=[\n",
+    "        {\n",
+    "            'ParameterKey': 'APIEndpoint',\n",
+    "            'ParameterValue':route_away_origin\n",
+    "        },\n",
+    "        {\n",
+    "            'ParameterKey': 'APIStage',\n",
+    "            'UsePreviousValue':True\n",
+    "        },\n",
+    "        {\n",
+    "            'ParameterKey': 'CName',\n",
+    "            'UsePreviousValue':True\n",
+    "        },\n",
+    "        {\n",
+    "            'ParameterKey': 'CertificateArn',\n",
+    "            'UsePreviousValue': True\n",
+    "        }\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "print response"
    ]
   },
   {

--- a/cf_gateway.ipynb
+++ b/cf_gateway.ipynb
@@ -452,11 +452,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 86,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[{\"checked\":false,\"createdAt\":1503099877549,\"text\":\"Research fear of clowns\",\"id\":\"322325d0-846f-11e7-814a-2ddad93bda20\",\"updatedAt\":1503099877549},{\"checked\":false,\"createdAt\":1503099571377,\"text\":\"Research fear of clowns\",\"id\":\"7ba50210-846e-11e7-814a-2ddad93bda20\",\"updatedAt\":1503099571377},{\"checked\":false,\"createdAt\":1503101676629,\"text\":\"Research fear of clowns\",\"id\":\"6278f850-8473-11e7-814a-2ddad93bda20\",\"updatedAt\":1503101676629},{\"checked\":false,\"createdAt\":1503099529474,\"text\":\"Research fear of clowns\",\"id\":\"62ab1e20-846e-11e7-814a-2ddad93bda20\",\"updatedAt\":1503099529474},{\"checked\":false,\"createdAt\":1503099490745,\"text\":\"Learn Serverless\",\"id\":\"4b958a90-846e-11e7-814a-2ddad93bda20\",\"updatedAt\":1503099490745}]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
+      "                                 Dload  Upload   Total   Spent    Left  Speed\n",
+      "\r",
+      "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r",
+      "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r",
+      "100   729  100   729    0     0    409      0  0:00:01  0:00:01 --:--:--   409\r",
+      "100   729  100   729    0     0    409      0  0:00:01  0:00:01 --:--:--   409\n"
+     ]
+    }
+   ],
    "source": [
     "%%bash -s \"$list_uri\" \"$key_val\"\n",
     "curl -H x-api-key:$2 $1"
@@ -464,11 +485,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 85,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"id\":\"6278f850-8473-11e7-814a-2ddad93bda20\",\"text\":\"Research fear of clowns\",\"checked\":false,\"createdAt\":1503101676629,\"updatedAt\":1503101676629}"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
+      "                                 Dload  Upload   Total   Spent    Left  Speed\n",
+      "\r",
+      "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r",
+      "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r",
+      "  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0\r",
+      "100   183  100   146  100    37     68     17  0:00:02  0:00:02 --:--:--    68\r",
+      "100   183  100   146  100    37     68     17  0:00:02  0:00:02 --:--:--    68\n"
+     ]
+    }
+   ],
    "source": [
     "%%bash -s \"$list_uri\" \"$key_val\"\n",
     "curl -X POST -H x-api-key:$2 $1 --data '{ \"text\": \"Research fear of clowns\" }'"
@@ -481,9 +524,7 @@
     "## Cloud Formation Update - Region Route Away\n",
     "\n",
     "This section shows how to update the api origin associated with the cloud front fronting the (cloud front\n",
-    "wrapping) the API endpoint.\n",
-    "\n",
-    "To do - how do we get the route away time down? Is it a TTL somewhere maybe in cloud front?"
+    "wrapping) the API endpoint."
    ]
   },
   {
@@ -543,6 +584,43 @@
     ")\n",
     "\n",
     "print response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 87,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "waiting on update of cf-api-pp1\n",
+      "stack updated\n"
+     ]
+    }
+   ],
+   "source": [
+    "print 'waiting on update of {}'.format(api_stack_name)\n",
+    "waiter = cformation_east.get_waiter('stack_update_complete')\n",
+    "waiter.wait(\n",
+    "    StackName=api_stack_name\n",
+    ")\n",
+    "\n",
+    "print 'stack updated'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 88,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# May need to invalidate the cache here."
    ]
   },
   {


### PR DESCRIPTION
This PR adds a section to the notebook that can be used to change the cloud front serverless app origin. This is what would be used when doing a route away.